### PR TITLE
Update extract.py

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -29,8 +29,7 @@ ep = -1
 sn = 0
 counter=0
 # Interate through file and do things with data.
-# length offset prevents index out of bounds error
-for i in range(len(array) + 1 - 4):
+for i in range(len(array)+1):
     # If the current byte = S and following bytes are N and D, set byte after SND to start position
     if array[i] == 83 and array[i+1] == 78 and array[i+2] == 68 and sp == -1:
         sp = i

--- a/extract.py
+++ b/extract.py
@@ -29,7 +29,8 @@ ep = -1
 sn = 0
 counter=0
 # Interate through file and do things with data.
-for i in range(len(array)+1):
+# length offset prevents index out of bounds error
+for i in range(len(array) + 1 - 4):
     # If the current byte = S and following bytes are N and D, set byte after SND to start position
     if array[i] == 83 and array[i+1] == 78 and array[i+2] == 68 and sp == -1:
         sp = i

--- a/raw-to-wav.py
+++ b/raw-to-wav.py
@@ -1,8 +1,6 @@
 # RAW to WAV
 # Written by 641i130
 import sys, wave, os
-# Set range of all raw files to put into a wav file or files
-x,y = 1,5859 # 5859
 
 # Make samples folder if non-exsistant
 if not os.path.exists("samples"):
@@ -12,6 +10,10 @@ try:
     fold = sys.argv[1]
 except:
     print("Please use:\npython raw-to-wav.py [folder name with raw files] [0 or 1]\n\nThis should be the name of the ddb file without the extension.\n0 as in seperate sample files.\n1 as in one large sample file.")
+    
+# Set range of all raw files to put into a wav file or files
+x = 1
+y = len(os.listdir(fold))
 
 for i in range(x,y+1):
     fi = "{}/s{}".format(fold,str(i))


### PR DESCRIPTION
I ran into some bounds errors when working with smaller .DDB files.

The commit to raw-to-wav.py prevents an error when the voicebank contains less than 5859 samples, such as below

`Traceback (most recent call last):
  File "~/ddb-extraction/raw-to-wav.py", line 22, in <module>
    with open(fi, "rb") as pcmfile:
FileNotFoundError: [Errno 2] No such file or directory: '~/v4flower/s2412'`

This will allow the program to convert all files in a voicebank that contains more than 5859 samples, especially for English language libraries.

I reverted my commit to extract.py due to the "if it ain't broke, don't fix it" law. The program does not current check if it is at EOF before searching for the terminating substring, but I have yet to encounter a voicebank that has samples all the way at the end. Got a little trigger happy, my bad...